### PR TITLE
(fixes): Summarization tab and related changes

### DIFF
--- a/web/src/catch_up_data.ts
+++ b/web/src/catch_up_data.ts
@@ -102,6 +102,53 @@ export async function fetch_topic_summary(
     });
 }
 
+/** Response shape from GET/POST `/json/catch-up/overview` (json_success payload). */
+export type CatchUpOverviewResponse = {
+    result?: string;
+    structured: boolean;
+    overview: string;
+    keywords: string[];
+    action_items: {
+        text: string;
+        assignee: string | null;
+        message_id: number | null;
+        narrow_url: string | null;
+    }[];
+    topics: {
+        stream: string;
+        topic: string;
+        summary: string;
+        narrow_url: string;
+        key_messages: {id: number; excerpt: string; narrow_url: string}[];
+    }[];
+    model_used: string;
+    message_count: number;
+};
+
+export async function fetch_catch_up_overview(
+    summary_preferences: string,
+): Promise<CatchUpOverviewResponse> {
+    const clipped = summary_preferences.slice(0, 4000);
+    return new Promise((resolve, reject) => {
+        void channel.post({
+            url: "/json/catch-up/overview",
+            data: {
+                summary_preferences: JSON.stringify(clipped),
+            },
+            success(raw_data) {
+                resolve(raw_data as CatchUpOverviewResponse);
+            },
+            error(xhr: JQuery.jqXHR) {
+                const parsed = xhr.responseJSON as {msg?: string} | undefined;
+                const msg =
+                    parsed?.msg ??
+                    `Failed to fetch catch-up overview (${String(xhr.status)})`;
+                reject(new Error(msg));
+            },
+        });
+    });
+}
+
 export function report_catch_up_usage(duration_ms: number): void {
     // Best-effort analytics; ignore failures.
     if (!Number.isFinite(duration_ms) || duration_ms <= 0) {

--- a/web/src/catch_up_ui.ts
+++ b/web/src/catch_up_ui.ts
@@ -6,6 +6,7 @@ import render_catch_up_view from "../templates/catch_up_view/catch_up_view.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import * as catch_up_data from "./catch_up_data.ts";
+import type {CatchUpOverviewResponse} from "./catch_up_data.ts";
 import type {CatchUpTopic} from "./catch_up_data.ts";
 import * as compose_closed_ui from "./compose_closed_ui.ts";
 import * as hash_util from "./hash_util.ts";
@@ -46,6 +47,12 @@ function stop_and_report_catch_up_usage_timer(): void {
 type FilterMode = "all" | "mentions" | "important" | "ai-summary";
 let current_filter: FilterMode = "all";
 let current_stream_filter: number | "all" = "all";
+
+/** Draft text for catch-up overview prompt preferences (survives filter re-renders). */
+let summary_preferences_draft = "";
+
+/** Whether the AI Summary tab instructions textarea is visible (hidden by default). */
+let ai_summary_instructions_expanded = false;
 
 // Keyboard navigation state
 let card_focus = -1;
@@ -139,21 +146,38 @@ function prepare_topic_for_render(topic: CatchUpTopic): Record<string, unknown> 
     };
 }
 
-function get_ai_summary_entries(
-    topics: CatchUpTopic[],
-): Array<{sender_full_name: string; rendered_content: string}> {
-    const entries: Array<{sender_full_name: string; rendered_content: string}> = [];
+/** Illustrative “time saved” metrics for the catch-up tab (dummy visualization). */
+function prepare_time_saved_context(
+    data: catch_up_data.CatchUpData,
+): Record<string, unknown> {
+    const messages = data.total_messages;
+    const topics = data.total_topics;
+    const minutes_saved = Math.min(120, Math.max(10, Math.round(messages * 0.4 + topics * 2.5)));
+    const minutes_linear = Math.min(480, Math.max(35, Math.round(messages * 1.35 + topics * 6)));
 
-    for (const topic of topics) {
-        for (const message of topic.all_messages) {
-            entries.push({
-                sender_full_name: message.sender_full_name,
-                rendered_content: message.rendered_content ?? message.content,
-            });
-        }
-    }
+    const seg_summaries_pct = 42;
+    const seg_priority_pct = 33;
+    const seg_skipped_pct = 25;
 
-    return entries;
+    const d1 = Math.round((360 * seg_summaries_pct) / 100);
+    const d2 = d1 + Math.round((360 * seg_priority_pct) / 100);
+
+    const catchup_bar_pct = Math.max(
+        18,
+        Math.min(100, Math.round((minutes_saved / minutes_linear) * 100)),
+    );
+
+    return {
+        minutes_saved,
+        minutes_linear,
+        seg_summaries_pct,
+        seg_priority_pct,
+        seg_skipped_pct,
+        seg_summaries_end_deg: d1,
+        seg_priority_end_deg: d2,
+        linear_bar_pct: 100,
+        catchup_bar_pct,
+    };
 }
 
 function get_unique_streams(
@@ -184,9 +208,13 @@ function render_empty(): void {
 }
 
 function render_data(data: catch_up_data.CatchUpData): void {
+    const $prefs_field = $("#catch-up-summary-preferences");
+    if ($prefs_field.length > 0) {
+        summary_preferences_draft = String($prefs_field.val() ?? "");
+    }
+
     const topics = data.topics.map((topic) => prepare_topic_for_render(topic));
     const streams = get_unique_streams(data.topics);
-    const ai_summary_entries = get_ai_summary_entries(data.topics);
 
     const html = render_catch_up_view({
         loading: false,
@@ -197,12 +225,12 @@ function render_data(data: catch_up_data.CatchUpData): void {
         topics,
         streams,
         has_streams: streams.length > 0,
-        has_ai_summary_entries: ai_summary_entries.length > 0,
-        ai_summary_entries,
         is_all_filter: current_filter === "all",
         is_mentions_filter: current_filter === "mentions",
         is_important_filter: current_filter === "important",
         is_ai_summary_filter: current_filter === "ai-summary",
+        catch_up_summary_preferences_value: summary_preferences_draft,
+        time_saved: prepare_time_saved_context(data),
     });
 
     $("#catch-up-pane").html(html);
@@ -217,8 +245,26 @@ function render_data(data: catch_up_data.CatchUpData): void {
     card_focus = -1;
 
     setup_event_handlers();
-    if (current_filter !== "ai-summary") {
+    if (current_filter === "ai-summary") {
+        sync_ai_summary_instructions_visibility();
+        load_ai_summary_overview(false);
+    } else {
         apply_filters();
+    }
+}
+
+function sync_ai_summary_instructions_visibility(): void {
+    const $block = $("#catch-up-preferences-collapsible");
+    const $toggle = $("#catch-up-summary-prefs-toggle");
+    if ($block.length === 0 || $toggle.length === 0) {
+        return;
+    }
+    if (ai_summary_instructions_expanded) {
+        $block.show();
+        $toggle.attr("aria-expanded", "true");
+    } else {
+        $block.hide();
+        $toggle.attr("aria-expanded", "false");
     }
 }
 
@@ -229,11 +275,31 @@ function setup_event_handlers(): void {
         if (!filter) {
             return;
         }
+        if (current_filter === "ai-summary" && filter !== "ai-summary") {
+            ai_summary_instructions_expanded = false;
+        }
         current_filter = filter;
         const data = catch_up_data.get_current_data();
         if (data !== undefined) {
             render_data(data);
         }
+    });
+
+    $("#catch-up-summary-preferences").on("input", function (this: HTMLTextAreaElement) {
+        summary_preferences_draft = this.value;
+    });
+
+    $("#catch-up-summary-prefs-toggle").on("click", () => {
+        ai_summary_instructions_expanded = !ai_summary_instructions_expanded;
+        sync_ai_summary_instructions_visibility();
+    });
+
+    $("#catch-up-regenerate-overview").on("click", () => {
+        const $ta = $("#catch-up-summary-preferences");
+        if ($ta.length > 0) {
+            summary_preferences_draft = String($ta.val() ?? "");
+        }
+        load_ai_summary_overview(true);
     });
 
     // Stream filter dropdown.
@@ -553,40 +619,79 @@ export function hide(): void {
     card_focus = -1;
     current_filter = "all";
     current_stream_filter = "all";
-    overview_open = false;
     cached_overview = null;
+    cached_overview_preferences_key = "";
+    summary_preferences_draft = "";
+    ai_summary_instructions_expanded = false;
     catch_up_data.clear_data();
 }
 
-// ── Global AI Summary (US-08: context linking across all missed messages) ─────
+// ── AI Summary tab: POST /json/catch-up/overview (US-08) ──────────────────────
 
-type OverviewActionItem = {
-    text: string;
-    assignee: string | null;
-    message_id: number | null;
-    narrow_url: string | null;
-};
+type OverviewResponse = CatchUpOverviewResponse;
 
-type OverviewTopic = {
-    stream: string;
-    topic: string;
-    summary: string;
-    narrow_url: string;
-    key_messages: {id: number; excerpt: string; narrow_url: string}[];
-};
-
-type OverviewResponse = {
-    structured: boolean;
-    overview: string;
-    keywords: string[];
-    action_items: OverviewActionItem[];
-    topics: OverviewTopic[];
-    model_used: string;
-    message_count: number;
-};
-
-let overview_open = false;
 let cached_overview: OverviewResponse | null = null;
+/** Preferences string used for `cached_overview`; regenerated when preferences differ. */
+let cached_overview_preferences_key = "";
+
+function wrap_overview_html(inner: string): string {
+    return `<div class="catch-up-overview-panel">${inner}</div>`;
+}
+
+function load_ai_summary_overview(force: boolean): void {
+    const $body = $("#catch-up-ai-summary-body");
+    if ($body.length === 0) {
+        return;
+    }
+
+    const prefs = String($("#catch-up-summary-preferences").val() ?? summary_preferences_draft);
+
+    if (
+        !force &&
+        cached_overview !== null &&
+        cached_overview_preferences_key === prefs
+    ) {
+        $body.html(
+            wrap_overview_html(
+                render_catch_up_overview_panel(prepare_overview_context(cached_overview)),
+            ),
+        );
+        return;
+    }
+
+    $body.html(
+        wrap_overview_html(
+            render_catch_up_overview_status({is_loading: true, error_msg: ""}),
+        ),
+    );
+
+    void catch_up_data
+        .fetch_catch_up_overview(prefs)
+        .then((data: OverviewResponse) => {
+            cached_overview = data;
+            cached_overview_preferences_key = prefs;
+            if (!$("#catch-up-ai-summary-body").length) {
+                return;
+            }
+            $("#catch-up-ai-summary-body").html(
+                wrap_overview_html(
+                    render_catch_up_overview_panel(prepare_overview_context(data)),
+                ),
+            );
+        })
+        .catch((error: unknown) => {
+            const error_msg =
+                error instanceof Error ? error.message : "Failed to generate summary.";
+            if (!$("#catch-up-ai-summary-body").length) {
+                return;
+            }
+            $("#catch-up-ai-summary-body").html(
+                wrap_overview_html(
+                    render_catch_up_overview_status({is_loading: false, error_msg}),
+                ),
+            );
+        });
+}
 
 function resolve_topic_url(stream: string, topic: string): string {
     const sub = stream_data.get_sub_by_name(stream);
@@ -630,33 +735,3 @@ function prepare_overview_context(data: OverviewResponse): object {
     };
 }
 
-$(document).on("click", "#catch-up-overview-btn", () => {
-    overview_open = !overview_open;
-    const $panel = $("#catch-up-overview-panel");
-
-    if (!overview_open) {
-        $panel.slideUp(150);
-        return;
-    }
-
-    if (cached_overview) {
-        $panel.html(render_catch_up_overview_panel(prepare_overview_context(cached_overview))).slideDown(160);
-        return;
-    }
-
-    $panel
-        .html(render_catch_up_overview_status({is_loading: true, error_msg: ""}))
-        .slideDown(160);
-
-    void $.get("/json/catch-up/overview")
-        .done((data: {result: string} & OverviewResponse) => {
-            cached_overview = data;
-            if (overview_open) {
-                $panel.html(render_catch_up_overview_panel(prepare_overview_context(data)));
-            }
-        })
-        .fail((xhr: {responseJSON?: {msg?: string}}) => {
-            const error_msg = (xhr.responseJSON?.msg) ?? "Failed to generate summary.";
-            $panel.html(render_catch_up_overview_status({is_loading: false, error_msg}));
-        });
-});

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -885,7 +885,9 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "vim_right":
         case "page_up":
         case "page_down":
-            if (catch_up_ui.is_in_focus()) {
+            // Skip when typing in the catch-up preferences textarea (or any
+            // input): otherwise vim keys like `l`/`h` are eaten as navigation.
+            if (catch_up_ui.is_in_focus() && !processing_text()) {
                 return catch_up_ui.change_focused_element(event_name);
             }
     }

--- a/web/styles/catch_up.css
+++ b/web/styles/catch_up.css
@@ -2,6 +2,8 @@
     display: none;
     min-height: 100vh;
     background: var(--color-background);
+    /* Keep light-dark() tokens aligned with the rest of the app (middle column). */
+    color-scheme: inherit;
 }
 
 #catch-up-pane {
@@ -91,6 +93,291 @@
 
     .zulip-icon {
         font-size: 14px;
+    }
+}
+
+/* Time saved (illustrative metrics) */
+.catch-up-time-saved {
+    margin: 0 0 20px;
+    padding: 16px 18px;
+    border: 1px solid var(--color-border-sidebar);
+    border-radius: 10px;
+    background: light-dark(
+        hsl(210deg 45% 98%),
+        color-mix(in srgb, var(--color-background) 88%, hsl(210deg 30% 22%))
+    );
+}
+
+.catch-up-time-saved-header {
+    margin-bottom: 14px;
+}
+
+.catch-up-time-saved-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 6px;
+    font-size: 1.05em;
+    font-weight: 600;
+    color: var(--color-text-default);
+
+    .zulip-icon {
+        font-size: 18px;
+        color: hsl(210deg 55% 48%);
+    }
+}
+
+.catch-up-time-saved-disclaimer {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--color-text-item);
+}
+
+.catch-up-time-saved-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    gap: 16px 20px;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.catch-up-time-saved-hero-metric {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    margin-bottom: 6px;
+}
+
+.catch-up-time-saved-hero-value {
+    font-size: 2.4em;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: hsl(210deg 55% 42%);
+}
+
+.catch-up-time-saved-hero-unit {
+    font-size: 1em;
+    font-weight: 600;
+    color: var(--color-text-item);
+}
+
+.catch-up-time-saved-hero-caption {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--color-text-default);
+    opacity: 0.85;
+}
+
+.catch-up-time-saved-donut-block {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+
+.catch-up-time-saved-donut {
+    position: relative;
+    flex-shrink: 0;
+    width: 92px;
+    height: 92px;
+    border-radius: 50%;
+    background: conic-gradient(
+        hsl(210deg 58% 48%) 0deg var(--d1, 151deg),
+        hsl(155deg 42% 40%) var(--d1, 151deg) var(--d2, 270deg),
+        color-mix(in srgb, var(--color-border-sidebar) 85%, var(--color-text-default)) var(--d2, 270deg) 360deg
+    );
+    box-shadow: 0 1px 4px hsl(0deg 0% 0% / 10%);
+}
+
+.catch-up-time-saved-donut::after {
+    content: "";
+    position: absolute;
+    inset: 20px;
+    border-radius: 50%;
+    background: light-dark(
+        hsl(210deg 45% 98%),
+        color-mix(in srgb, var(--color-background) 88%, hsl(210deg 30% 22%))
+    );
+}
+
+.catch-up-time-saved-donut-legend {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--color-text-default);
+}
+
+.catch-up-time-saved-donut-legend li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 2px;
+}
+
+.catch-up-time-saved-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.catch-up-time-saved-swatch-a {
+    background: hsl(210deg 58% 48%);
+}
+
+.catch-up-time-saved-swatch-b {
+    background: hsl(155deg 42% 40%);
+}
+
+.catch-up-time-saved-swatch-c {
+    background: color-mix(in srgb, var(--color-border-sidebar) 85%, var(--color-text-default));
+}
+
+.catch-up-time-saved-compare {
+    margin-bottom: 14px;
+    padding-top: 4px;
+    border-top: 1px solid var(--color-border-sidebar);
+}
+
+.catch-up-time-saved-compare-label {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-item);
+}
+
+.catch-up-time-saved-compare-row {
+    display: grid;
+    grid-template-columns: minmax(100px, 150px) 1fr;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.catch-up-time-saved-compare-name {
+    font-size: 12px;
+    color: var(--color-text-default);
+}
+
+.catch-up-time-saved-compare-track {
+    height: 10px;
+    border-radius: 5px;
+    background: var(--color-background-navbar);
+    overflow: hidden;
+}
+
+.catch-up-time-saved-compare-fill {
+    height: 100%;
+    border-radius: 5px;
+    min-width: 4px;
+    transition: width 0.35s ease;
+}
+
+.catch-up-time-saved-compare-fill-linear {
+    background: linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--color-text-default) 35%, var(--color-border-sidebar)),
+        color-mix(in srgb, var(--color-text-default) 22%, var(--color-border-sidebar))
+    );
+}
+
+.catch-up-time-saved-compare-fill-catchup {
+    background: linear-gradient(90deg, hsl(210deg 58% 48%), hsl(200deg 50% 55%));
+}
+
+.catch-up-time-saved-stack-label {
+    margin: 0 0 6px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-item);
+}
+
+.catch-up-time-saved-stack-bar {
+    display: flex;
+    height: 12px;
+    border-radius: 6px;
+    overflow: hidden;
+    margin-bottom: 8px;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-text-default) 8%, transparent);
+}
+
+.catch-up-time-saved-stack-seg {
+    display: block;
+    height: 100%;
+    min-width: 2px;
+}
+
+.catch-up-time-saved-stack-summaries {
+    background: hsl(210deg 58% 48%);
+}
+
+.catch-up-time-saved-stack-priority {
+    background: hsl(155deg 42% 40%);
+}
+
+.catch-up-time-saved-stack-skipped {
+    background: color-mix(in srgb, var(--color-border-sidebar) 75%, var(--color-text-default));
+}
+
+.catch-up-time-saved-stack-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    font-size: 11px;
+    color: var(--color-text-default);
+}
+
+.catch-up-time-saved-stack-legend > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.catch-up-time-saved-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.catch-up-time-saved-dot-summaries {
+    background: hsl(210deg 58% 48%);
+}
+
+.catch-up-time-saved-dot-priority {
+    background: hsl(155deg 42% 40%);
+}
+
+.catch-up-time-saved-dot-skipped {
+    background: color-mix(in srgb, var(--color-border-sidebar) 75%, var(--color-text-default));
+}
+
+@media (width <= 750px) {
+    .catch-up-time-saved-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .catch-up-time-saved-donut-block {
+        justify-content: flex-start;
+    }
+
+    .catch-up-time-saved-compare-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+    }
+
+    .catch-up-time-saved-compare-name {
+        font-size: 11px;
     }
 }
 
@@ -207,11 +494,63 @@
     }
 }
 
-.catch-up-ai-summary-block {
-    padding: 16px 18px;
+.catch-up-ai-summary-tab {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.catch-up-ai-summary-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.catch-up-summary-prefs-toggle {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border-sidebar);
+    background: transparent;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-default);
+    cursor: pointer;
+}
+
+.catch-up-summary-prefs-toggle:hover {
+    background: hsl(0 0% 0% / 0.04);
+}
+
+.catch-up-preferences-collapsible {
+    padding: 12px 14px;
     border: 1px solid var(--color-border-sidebar);
     border-radius: 8px;
     background: var(--color-background);
+}
+
+.catch-up-regenerate-overview-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 6px;
+    background: hsl(218 57% 28%);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+}
+
+.catch-up-regenerate-overview-btn:hover {
+    background: hsl(218 57% 22%);
+}
+
+.catch-up-ai-summary-body {
+    min-height: 80px;
 }
 
 .catch-up-expand-btn {
@@ -417,36 +756,6 @@
     padding: 3px 0;
 }
 
-.catch-up-ai-summary-list {
-    margin: 0 0 0 18px;
-    padding: 0;
-}
-
-.catch-up-ai-summary-item {
-    margin-bottom: 8px;
-    color: var(--color-text-default);
-    line-height: 1.5;
-}
-
-.catch-up-ai-summary-sender {
-    display: inline;
-}
-
-.catch-up-ai-summary-message {
-    display: inline;
-
-    p {
-        display: inline;
-        margin: 0;
-    }
-}
-
-.catch-up-ai-summary-empty {
-    margin: 0 0 12px;
-    color: var(--color-text-default);
-    opacity: 0.7;
-}
-
 .catch-up-preview-message {
     display: inline;
     color: var(--color-text-default);
@@ -583,35 +892,45 @@
     }
 }
 
-/* ── Global AI Summary panel (US-08: context linking) ── */
+/* ── AI Summary tab: overview panel (US-08) ── */
 
-.catch-up-overview-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 6px 16px;
-    border-radius: 20px;
-    background: hsl(218 57% 28%);
-    color: #fff;
-    font-size: 13px;
-    font-weight: 700;
-    border: none;
-    cursor: pointer;
-    white-space: nowrap;
-    box-shadow: 0 2px 6px rgba(0 0 0 / 0.2);
+.catch-up-preferences-label {
+    display: block;
+    font-weight: 600;
+    font-size: 0.9em;
+    margin-bottom: 4px;
+    color: var(--color-text-default);
 }
 
-.catch-up-overview-btn:hover {
-    background: hsl(218 57% 22%);
+.catch-up-preferences-hint {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--color-text-default);
+    opacity: 0.75;
+}
+
+.catch-up-summary-preferences {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 4.5em;
+    padding: 8px 10px;
+    border: 1px solid var(--color-border-sidebar);
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--color-text-default);
+    background: var(--color-background);
+    resize: vertical;
 }
 
 .catch-up-overview-panel {
     margin: 0 0 16px;
-    border: 1px solid var(--color-border-sidebar, #e0e4ea);
+    border: 1px solid var(--color-border-sidebar);
     border-radius: 10px;
     overflow: hidden;
-    background: var(--color-background, #fff);
-    box-shadow: 0 2px 12px rgba(0 0 0 / 0.08);
+    background: var(--color-background);
+    box-shadow: 0 2px 12px color-mix(in srgb, var(--color-text-default) 6%, transparent);
 }
 
 .catch-up-overview-body {
@@ -632,7 +951,7 @@
 .catch-up-overview-section-label {
     font-size: 11px;
     font-weight: 700;
-    color: #888;
+    color: var(--color-text-item);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 6px;
@@ -640,8 +959,9 @@
 
 .catch-up-keyword-pill {
     display: inline-block;
-    background: hsl(230 100% 95%);
-    color: hsl(230 57% 38%);
+    background: color-mix(in srgb, var(--color-text-default) 6%, var(--color-background));
+    color: var(--color-text-default);
+    border: 1px solid var(--color-border-sidebar);
     border-radius: 4px;
     padding: 2px 8px;
     font-size: 12px;
@@ -659,14 +979,15 @@
     display: flex;
     align-items: flex-start;
     gap: 8px;
-    background: hsl(230 100% 98%);
-    border: 1px solid hsl(230 100% 90%);
+    background: color-mix(in srgb, var(--color-text-default) 6%, var(--color-background));
+    border: 1px solid var(--color-border-sidebar);
     border-radius: 6px;
     padding: 7px 12px;
+    color: var(--color-text-default);
 }
 
 .catch-up-action-bullet {
-    color: hsl(230 57% 48%);
+    color: var(--color-text-url);
     flex-shrink: 0;
     margin-top: 1px;
 }
@@ -675,11 +996,12 @@
     flex: 1;
     font-size: 13.5px;
     line-height: 1.5;
+    color: var(--color-text-default);
 }
 
 .catch-up-assignee-badge {
-    background: hsl(45 100% 92%);
-    color: hsl(30 80% 30%);
+    background: light-dark(hsl(45deg 100% 92%), hsl(45deg 25% 22%));
+    color: light-dark(hsl(30deg 80% 30%), hsl(45deg 70% 82%));
     border-radius: 4px;
     padding: 1px 7px;
     font-size: 11px;
@@ -688,7 +1010,7 @@
 }
 
 .catch-up-context-link {
-    color: hsl(218 57% 38%);
+    color: var(--color-text-url);
     font-weight: 600;
     font-size: 12px;
     text-decoration: none;
@@ -697,6 +1019,7 @@
 }
 
 .catch-up-context-link:hover {
+    color: var(--color-text-url-hover);
     text-decoration: underline;
 }
 
@@ -707,9 +1030,10 @@
 }
 
 .catch-up-topic-summary-card {
-    border: 1px solid var(--color-border-sidebar, #e0e4ea);
+    border: 1px solid var(--color-border-sidebar);
     border-radius: 8px;
     overflow: hidden;
+    background: var(--color-background);
 }
 
 .catch-up-topic-summary-header {
@@ -717,8 +1041,10 @@
     align-items: center;
     gap: 8px;
     padding: 7px 12px;
-    background: var(--color-background-sidebar, #f5f7fa);
-    border-bottom: 1px solid var(--color-border-sidebar, #e8edf2);
+    /* Avoid light-dark() alone on navbar tokens: mix from the same base as #catch-up-view. */
+    background: color-mix(in srgb, var(--color-text-default) 7%, var(--color-background));
+    border-bottom: 1px solid var(--color-border-sidebar);
+    color: var(--color-text-default);
 }
 
 .catch-up-stream-badge {
@@ -735,6 +1061,7 @@
     flex: 1;
     font-size: 13px;
     font-weight: 600;
+    color: var(--color-text-default);
 }
 
 .catch-up-topic-summary-text {
@@ -749,11 +1076,11 @@
     align-items: flex-start;
     gap: 6px;
     padding: 4px 12px;
-    border-top: 1px solid var(--color-border-sidebar, #f0f2f5);
+    border-top: 1px solid var(--color-border-sidebar);
 }
 
 .catch-up-key-message-arrow {
-    color: #aaa;
+    color: var(--color-text-item);
     font-size: 11px;
     flex-shrink: 0;
     margin-top: 2px;
@@ -762,16 +1089,17 @@
 .catch-up-key-message-text {
     flex: 1;
     font-size: 12.5px;
-    color: #555;
+    color: var(--color-text-default);
+    opacity: 0.85;
     line-height: 1.5;
 }
 
 .catch-up-overview-footer {
     margin-top: 12px;
     padding-top: 10px;
-    border-top: 1px solid var(--color-border-sidebar, #f0f2f5);
+    border-top: 1px solid var(--color-border-sidebar);
     font-size: 11px;
-    color: #aaa;
+    color: var(--color-text-item);
     display: flex;
     justify-content: space-between;
 }
@@ -780,11 +1108,11 @@
 .catch-up-overview-error {
     padding: 16px 20px;
     font-size: 14px;
-    color: #888;
+    color: var(--color-text-item);
     font-style: italic;
 }
 
 .catch-up-overview-error {
-    color: #c0392b;
+    color: var(--color-text-danger-text-action-button);
     font-style: normal;
 }

--- a/web/templates/catch_up_view/catch_up_time_saved.hbs
+++ b/web/templates/catch_up_view/catch_up_time_saved.hbs
@@ -1,0 +1,56 @@
+<section class="catch-up-time-saved" aria-labelledby="catch-up-time-saved-heading">
+    <div class="catch-up-time-saved-header">
+        <h2 id="catch-up-time-saved-heading" class="catch-up-time-saved-title">
+            <i class="zulip-icon zulip-icon-clock" aria-hidden="true"></i>
+            {{t "Time saved with catch-up" }}
+        </h2>
+        <p class="catch-up-time-saved-disclaimer">{{t "Illustrative preview — real usage metrics will ship later." }}</p>
+    </div>
+    <div class="catch-up-time-saved-grid">
+        <div class="catch-up-time-saved-hero">
+            <div class="catch-up-time-saved-hero-metric">
+                <span class="catch-up-time-saved-hero-value" aria-hidden="true">~{{minutes_saved}}</span>
+                <span class="catch-up-time-saved-hero-unit">{{t "min" }}</span>
+            </div>
+            <p class="catch-up-time-saved-hero-caption">
+                {{t "Versus roughly {minutes_linear} minutes to read the same activity linearly (estimate)." minutes_linear=minutes_linear }}
+            </p>
+        </div>
+        <div class="catch-up-time-saved-donut-block">
+            <div class="catch-up-time-saved-donut" style="--d1: {{seg_summaries_end_deg}}deg; --d2: {{seg_priority_end_deg}}deg;"></div>
+            <ul class="catch-up-time-saved-donut-legend">
+                <li><span class="catch-up-time-saved-swatch catch-up-time-saved-swatch-a"></span> {{t "Summaries & highlights" }}</li>
+                <li><span class="catch-up-time-saved-swatch catch-up-time-saved-swatch-b"></span> {{t "Mentions & decisions" }}</li>
+                <li><span class="catch-up-time-saved-swatch catch-up-time-saved-swatch-c"></span> {{t "Low-signal threads skipped" }}</li>
+            </ul>
+        </div>
+    </div>
+    <div class="catch-up-time-saved-compare">
+        <p class="catch-up-time-saved-compare-label">{{t "Time to get oriented (illustrative)" }}</p>
+        <div class="catch-up-time-saved-compare-row">
+            <span class="catch-up-time-saved-compare-name">{{t "Reading every message" }}</span>
+            <div class="catch-up-time-saved-compare-track">
+                <div class="catch-up-time-saved-compare-fill catch-up-time-saved-compare-fill-linear" style="width: {{linear_bar_pct}}%;"></div>
+            </div>
+        </div>
+        <div class="catch-up-time-saved-compare-row">
+            <span class="catch-up-time-saved-compare-name">{{t "Catch-up view" }}</span>
+            <div class="catch-up-time-saved-compare-track">
+                <div class="catch-up-time-saved-compare-fill catch-up-time-saved-compare-fill-catchup" style="width: {{catchup_bar_pct}}%;"></div>
+            </div>
+        </div>
+    </div>
+    <div class="catch-up-time-saved-stack">
+        <p class="catch-up-time-saved-stack-label">{{t "Where catch-up focused you (sample)" }}</p>
+        <div class="catch-up-time-saved-stack-bar" role="presentation">
+            <span class="catch-up-time-saved-stack-seg catch-up-time-saved-stack-summaries" style="width: {{seg_summaries_pct}}%;"></span>
+            <span class="catch-up-time-saved-stack-seg catch-up-time-saved-stack-priority" style="width: {{seg_priority_pct}}%;"></span>
+            <span class="catch-up-time-saved-stack-seg catch-up-time-saved-stack-skipped" style="width: {{seg_skipped_pct}}%;"></span>
+        </div>
+        <div class="catch-up-time-saved-stack-legend">
+            <span><span class="catch-up-time-saved-dot catch-up-time-saved-dot-summaries"></span> {{t "Summaries" }} {{seg_summaries_pct}}%</span>
+            <span><span class="catch-up-time-saved-dot catch-up-time-saved-dot-priority"></span> {{t "Priority threads" }} {{seg_priority_pct}}%</span>
+            <span><span class="catch-up-time-saved-dot catch-up-time-saved-dot-skipped"></span> {{t "Deferred" }} {{seg_skipped_pct}}%</span>
+        </div>
+    </div>
+</section>

--- a/web/templates/catch_up_view/catch_up_view.hbs
+++ b/web/templates/catch_up_view/catch_up_view.hbs
@@ -29,12 +29,11 @@
                 <i class="zulip-icon zulip-icon-hash" aria-hidden="true"></i>
                 {{total_topics}} {{t "topics" }}
             </span>
-            <button id="catch-up-overview-btn" class="catch-up-overview-btn" tabindex="0">
-                ✦ {{t "AI Summary" }}
-            </button>
         </div>
     </div>
-    <div id="catch-up-overview-panel" class="catch-up-overview-panel" style="display:none;"></div>
+    {{#if time_saved}}
+    {{> catch_up_time_saved time_saved}}
+    {{/if}}
     <div class="catch-up-filters" role="group" aria-label="{{t 'Filters' }}">
         <div class="catch-up-filter-buttons">
             <button class="catch-up-filter-btn {{#if is_all_filter}}active{{/if}}" data-filter="all" tabindex="0">
@@ -65,19 +64,21 @@
         {{/if}}
     </div>
     {{#if is_ai_summary_filter}}
-    <div class="catch-up-ai-summary-block">
-        {{#if has_ai_summary_entries}}
-        <ul class="catch-up-ai-summary-list">
-            {{#each ai_summary_entries}}
-            <li class="catch-up-ai-summary-item">
-                <strong class="catch-up-ai-summary-sender">{{sender_full_name}}:</strong>
-                <div class="catch-up-ai-summary-message rendered_markdown">{{rendered_markdown rendered_content}}</div>
-            </li>
-            {{/each}}
-        </ul>
-        {{else}}
-        <p class="catch-up-ai-summary-empty">{{t "No messages available for the summary view." }}</p>
-        {{/if}}
+    <div class="catch-up-ai-summary-tab">
+        <div class="catch-up-ai-summary-toolbar">
+            <button type="button" id="catch-up-summary-prefs-toggle" class="catch-up-summary-prefs-toggle" aria-expanded="false" aria-controls="catch-up-preferences-collapsible">
+                {{t "Instructions" }}
+            </button>
+            <button type="button" id="catch-up-regenerate-overview" class="catch-up-regenerate-overview-btn">
+                {{t "Regenerate summary" }}
+            </button>
+        </div>
+        <div id="catch-up-preferences-collapsible" class="catch-up-preferences-collapsible" style="display: none;" aria-label="{{t 'Summary preferences' }}">
+            <label for="catch-up-summary-preferences" class="catch-up-preferences-label">{{t "Summary preferences" }}</label>
+            <p class="catch-up-preferences-hint">{{t "Optional instructions added to the AI prompt (tone, focus, what to skip)." }}</p>
+            <textarea id="catch-up-summary-preferences" class="catch-up-summary-preferences" rows="4" maxlength="4000" placeholder="{{t 'E.g. focus on decisions and blockers; skip social chatter.' }}">{{catch_up_summary_preferences_value}}</textarea>
+        </div>
+        <div id="catch-up-ai-summary-body" class="catch-up-ai-summary-body"></div>
     </div>
     {{else}}
     <div id="catch-up-no-filter-results" class="catch-up-no-filter-results" style="display: none;">

--- a/web/tests/catch_up_templates.test.cjs
+++ b/web/tests/catch_up_templates.test.cjs
@@ -12,7 +12,7 @@ const {initialize_user_settings} = zrequire("user_settings");
 
 initialize_user_settings({user_settings: {}});
 
-run_test("catch_up_view AI Summary mode renders page-level summary block", ({mock_template}) => {
+run_test("catch_up_view AI Summary tab has preferences and overview body mount", ({mock_template}) => {
     mock_template("catch_up_view/catch_up_view.hbs", true, (_data, html) => html);
 
     const html = require("../templates/catch_up_view/catch_up_view.hbs")({
@@ -24,22 +24,31 @@ run_test("catch_up_view AI Summary mode renders page-level summary block", ({moc
         topics: [],
         streams: [{id: 1, name: "design"}],
         has_streams: true,
-        has_ai_summary_entries: true,
-        ai_summary_entries: [
-            {
-                sender_full_name: "aaron",
-                rendered_content: "<p>Please review <strong>this</strong>.</p>",
-            },
-        ],
         is_all_filter: false,
         is_mentions_filter: false,
         is_important_filter: false,
         is_ai_summary_filter: true,
+        catch_up_summary_preferences_value: "",
+        time_saved: {
+            minutes_saved: 10,
+            minutes_linear: 35,
+            seg_summaries_pct: 42,
+            seg_priority_pct: 33,
+            seg_skipped_pct: 25,
+            seg_summaries_end_deg: 151,
+            seg_priority_end_deg: 270,
+            linear_bar_pct: 100,
+            catchup_bar_pct: 29,
+        },
     });
 
-    assert.match(html, /catch-up-ai-summary-block/);
-    assert.match(html, /aaron:/);
-    assert.match(html, /<strong>this<\/strong>/);
+    assert.match(html, /catch-up-time-saved/);
+    assert.match(html, /catch-up-ai-summary-tab/);
+    assert.match(html, /catch-up-summary-preferences/);
+    assert.match(html, /catch-up-regenerate-overview/);
+    assert.match(html, /catch-up-summary-prefs-toggle/);
+    assert.match(html, /catch-up-preferences-collapsible/);
+    assert.match(html, /catch-up-ai-summary-body/);
     assert.doesNotMatch(html, /catch-up-topics-container/);
     assert.doesNotMatch(html, /catch-up-stream-filter/);
 });
@@ -84,14 +93,25 @@ run_test("catch_up_view standard mode renders topics container and stream filter
         ],
         streams: [{id: 1, name: "design"}],
         has_streams: true,
-        has_ai_summary_entries: false,
-        ai_summary_entries: [],
         is_all_filter: true,
         is_mentions_filter: false,
         is_important_filter: false,
         is_ai_summary_filter: false,
+        catch_up_summary_preferences_value: "",
+        time_saved: {
+            minutes_saved: 12,
+            minutes_linear: 40,
+            seg_summaries_pct: 42,
+            seg_priority_pct: 33,
+            seg_skipped_pct: 25,
+            seg_summaries_end_deg: 151,
+            seg_priority_end_deg: 270,
+            linear_bar_pct: 100,
+            catchup_bar_pct: 30,
+        },
     });
 
+    assert.match(html, /catch-up-time-saved/);
     assert.match(html, /catch-up-topics-container/);
     assert.match(html, /catch-up-stream-filter/);
     assert.match(html, /catch-up-topic-card/);

--- a/zerver/lib/catchup_claude.py
+++ b/zerver/lib/catchup_claude.py
@@ -9,27 +9,10 @@ context navigation (US-08).
 Response schema
 ---------------
 {
-  "overview": "2-3 sentence overview",
+  "overview": "one ultra-short paragraph (see system prompt length limits)",
   "keywords": ["kw1", ...],
-  "action_items": [
-    {
-      "text": "...",
-      "assignee": "name or null",
-      "message_id": 1234,          ← exact source message
-      "narrow_url": "#narrow/..."  ← deep link to that message's topic
-    }
-  ],
-  "topics": [
-    {
-      "stream": "devel",
-      "topic": "Sprint 2 planning",
-      "summary": "1-2 sentence summary",
-      "narrow_url": "#narrow/...",
-      "key_messages": [
-        {"id": 1001, "excerpt": "...", "narrow_url": "..."}
-      ]
-    }
-  ]
+  "action_items": [...],
+  "topics": [...]
 }
 """
 
@@ -39,6 +22,8 @@ import json
 import re
 from dataclasses import dataclass, field
 from typing import Any
+
+from django.conf import settings
 
 from zerver.lib.url_encoding import encode_channel, encode_hash_component
 
@@ -119,6 +104,19 @@ def _narrow_url(stream_id: int, stream_name: str, topic: str) -> str:
     return f"#narrow/{encode_channel(stream_id, stream_name, with_operator=True)}/topic/{encode_hash_component(topic)}"
 
 
+def _mention_kind_for_reader(flags: list[str]) -> str | None:
+    """How this message notified the reader, from UserMessage API flags."""
+    if "mentioned" in flags:
+        return "user"
+    if "group_mentioned" in flags:
+        return "group"
+    if "stream_wildcard_mentioned" in flags:
+        return "stream_wildcard"
+    if "topic_wildcard_mentioned" in flags:
+        return "topic_wildcard"
+    return None
+
+
 def _build_context(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Convert raw Zulip message dicts into a compact context list for Claude.
@@ -135,6 +133,7 @@ def _build_context(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             else (raw_recipient[0].get("name", "") if raw_recipient else "")
         )
         topic = msg.get("subject", "")
+        flags = msg.get("flags") if isinstance(msg.get("flags"), list) else []
 
         context.append({
             "id": msg.get("id"),
@@ -143,23 +142,35 @@ def _build_context(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "stream": stream_name,
             "topic": topic,
             "narrow_url": _narrow_url(stream_id, stream_name, topic),
+            "mention_to_reader": _mention_kind_for_reader(flags),
         })
     return context
 
 
 # ── Prompt ────────────────────────────────────────────────────────────────────
 
-_SYSTEM_PROMPT = """You are an AI assistant helping a user catch up on Zulip messages they missed.
+_SYSTEM_PROMPT = """You are an AI assistant helping ONE specific person catch up on Zulip messages they missed.
+
+The user message will name that person (the reader). Write the entire summary as if you are speaking to them directly: use "you" and "your"; never refer to the reader in the third person (no "they/them" for the reader).
+
+Be extremely brief. They want a skim, not an essay.
+
+Each input message may include "mention_to_reader": if set, that message notified the reader — how they were pinged matters for tone:
+- "user" — the sender @-mentioned them by name (say things like "<Sender> tagged you" or "@-mentioned you").
+- "group" — a user group they belong to was @-mentioned (say they were mentioned via that group).
+- "stream_wildcard" / "topic_wildcard" — a stream-wide or topic-wide @-mention reached them (say e.g. "@**topic** included you" or "you were pinged with everyone in this topic").
+
+When summarizing a thread where the reader was personally notified, prefer lines like "<Sender> tagged you in this thread …" or "You were @-mentioned because …" instead of flat third-person reportage ("Aaron said to Shiv …"). If they were not mentioned, you may still use second person ("You missed …", "People discussed …").
 
 Analyse the provided messages and return ONLY a valid JSON object — no markdown fences, no explanation.
 
 Required JSON schema:
 {
-  "overview": "<2-3 sentence plain-English summary of all missed activity>",
-  "keywords": ["<up to 6 short keywords>"],
+  "overview": "<at most 2 short sentences OR roughly 50 words total — what mattered most to YOU (the reader), period>",
+  "keywords": ["<up to 5 single-word or two-word keywords>"],
   "action_items": [
     {
-      "text": "<concise action item>",
+      "text": "<max ~12 words — the action only>",
       "assignee": "<person's name, or null if unspecified>",
       "message_id": <integer id of the message this action came from>,
       "narrow_url": "<narrow_url value from that message — copy exactly>"
@@ -169,12 +180,12 @@ Required JSON schema:
     {
       "stream": "<stream name>",
       "topic": "<topic name>",
-      "summary": "<1-2 sentence summary>",
+      "summary": "<one short sentence, max ~20 words, addressed to the reader when a ping/mention applies>",
       "narrow_url": "<narrow_url for this topic — copy from a message in this topic>",
       "key_messages": [
         {
           "id": <integer message id>,
-          "excerpt": "<10-15 word quote or paraphrase of why this message matters>",
+          "excerpt": "<max ~8 words>",
           "narrow_url": "<narrow_url — copy exactly from the message>"
         }
       ]
@@ -183,10 +194,11 @@ Required JSON schema:
 }
 
 Rules:
-- Include only genuine action items (TODOs, assignments, requests) found verbatim in the messages.
+- Include only genuine action items (TODOs, assignments, requests) grounded in the messages.
 - Every action item must reference the exact message_id it was extracted from.
-- key_messages: pick 1-3 most important messages per topic.
+- key_messages: at most 2 entries per topic unless the user preferences explicitly ask for more detail.
 - narrow_url: always copy the value exactly from the input — never construct it yourself.
+- If the user provided preferences in their message, follow them for tone and focus, but still respect the brevity limits above.
 - Return valid JSON only.
 """
 
@@ -198,6 +210,9 @@ def summarize_with_claude(
     model: str,
     api_key: str | None,
     extra_params: dict[str, Any] | None = None,
+    user_preferences: str | None = None,
+    *,
+    reader_full_name: str = "",
 ) -> CatchUpSummary:
     """
     Call Claude via LiteLLM with the full message context and return a
@@ -207,15 +222,42 @@ def summarize_with_claude(
     """
     import litellm  # imported here per Zulip convention (avoids DeprecationWarning)
 
+    if settings.DEBUG:
+        # Option B from LiteLLM docs: verbose request/response logging. Can leak API
+        # keys and message text into the console — only when Django DEBUG is on.
+        turn_on_debug = getattr(litellm, "_turn_on_debug", None)
+        if callable(turn_on_debug):
+            turn_on_debug()
+        else:
+            litellm.set_verbose(True)
+
     context = _build_context(messages)
     user_content = json.dumps(context, ensure_ascii=False)
+
+    reader_line = ""
+    name = reader_full_name.strip()
+    if name:
+        reader_line = (
+            f"You are summarizing for the reader named «{name}». "
+            "Address all overview and topic text to them as «you»; they are the one catching up.\n\n"
+        )
+
+    preference_block = ""
+    if user_preferences and user_preferences.strip():
+        preference_block = (
+            "User preferences for this summary (apply when they do not conflict with "
+            "schema or safety; still keep output very short):\n"
+            f"{user_preferences.strip()}\n\n"
+        )
 
     llm_messages = [
         {"role": "system", "content": _SYSTEM_PROMPT},
         {
             "role": "user",
             "content": (
-                f"Here are the {len(context)} messages the user missed:\n\n"
+                f"{reader_line}"
+                f"{preference_block}"
+                f"Here are the {len(context)} messages they missed:\n\n"
                 f"{user_content}\n\n"
                 "Return the JSON summary."
             ),

--- a/zerver/views/catchup_overview.py
+++ b/zerver/views/catchup_overview.py
@@ -1,9 +1,13 @@
 """
 GET /json/catch-up/overview
+POST /json/catch-up/overview
 
 Returns a Claude-generated structured summary of ALL messages the user
 missed across every channel — overview, keywords, action items with
 source-message deep links, and per-topic summaries with jump links (US-08).
+
+POST accepts optional `summary_preferences` (JSON-encoded string) merged
+into the model prompt so the user can steer tone and focus.
 
 This is distinct from GET /json/catch-up/summary, which generates a
 per-topic summary for a single stream/topic pair.
@@ -11,35 +15,58 @@ per-topic summary for a single stream/topic pair.
 
 from __future__ import annotations
 
+import logging
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
+from pydantic import Json
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import messages_for_ids
 from zerver.lib.narrow import AnchorInfo, fetch_messages
 from zerver.lib.response import json_success
-from zerver.lib.typed_endpoint import typed_endpoint_without_parameters
-from zerver.models import UserProfile
+from zerver.lib.typed_endpoint import typed_endpoint, typed_endpoint_without_parameters
+from zerver.models import UserMessage, UserProfile
 from zerver.models.realms import MessageEditHistoryVisibilityPolicyEnum
 
 MAX_OVERVIEW_MESSAGES = 200
+MAX_SUMMARY_PREFERENCES_LENGTH = 2000
+
+logger = logging.getLogger(__name__)
 
 
-@typed_endpoint_without_parameters
-def get_catch_up_overview(
+def _client_safe_llm_error_message(exc: BaseException, *, max_len: int = 350) -> str:
+    """LiteLLM/provider errors are often huge HTML/JSON blobs; keep API responses bounded."""
+    text = str(exc).strip().replace("\n", " ")
+    if not text:
+        text = type(exc).__name__
+    if len(text) > max_len:
+        return f"{text[: max_len - 3]}..."
+    return text
+
+
+def _generate_catch_up_overview(
     request: HttpRequest,
     user_profile: UserProfile,
+    summary_preferences: str | None,
 ) -> HttpResponse:
-    """
-    Generate a Claude-powered structured overview of ALL unread messages.
-    Fetches all unread messages then sends them to Claude for a global
-    summary with per-action-item and per-topic context links (US-08).
-    """
     model = settings.TOPIC_SUMMARIZATION_MODEL
     api_key = getattr(settings, "TOPIC_SUMMARIZATION_API_KEY", None)
 
+    if api_key is not None and api_key != "":
+        logger.info(
+            "catch-up/overview: TOPIC_SUMMARIZATION_API_KEY length is %d characters",
+            len(api_key),
+        )
+    else:
+        logger.info("catch-up/overview: TOPIC_SUMMARIZATION_API_KEY is unset or empty")
+
     if model is None:
         raise JsonableError("AI features are not enabled on this server.")
+
+    prefs = (summary_preferences or "").strip()
+    if len(prefs) > MAX_SUMMARY_PREFERENCES_LENGTH:
+        prefs = prefs[:MAX_SUMMARY_PREFERENCES_LENGTH]
 
     query_info = fetch_messages(
         narrow=None,
@@ -57,6 +84,11 @@ def get_catch_up_overview(
 
     result_message_ids: list[int] = [row[0] for row in query_info.rows]
     user_message_flags: dict[int, list[str]] = {mid: [] for mid in result_message_ids}
+    for um in UserMessage.objects.filter(
+        user_profile=user_profile,
+        message_id__in=result_message_ids,
+    ).only("message_id", "flags"):
+        user_message_flags[um.message_id] = um.flags_list()
 
     message_list = messages_for_ids(
         message_ids=result_message_ids,
@@ -80,9 +112,39 @@ def get_catch_up_overview(
             messages=message_list,
             model=model,
             api_key=api_key,
-            extra_params={},
+            extra_params=dict(settings.TOPIC_SUMMARIZATION_PARAMETERS),
+            user_preferences=prefs or None,
+            reader_full_name=user_profile.full_name,
         )
     except Exception as e:
-        raise JsonableError(f"Claude API error: {e}") from e
+        # Full detail in server logs; clients get a short `msg` (see middleware access-log truncation).
+        logger.exception("catch-up/overview: summarization failed")
+        raise JsonableError(
+            f"Could not generate summary: {_client_safe_llm_error_message(e)}",
+        ) from e
 
     return json_success(request, {"structured": True, **summary.to_dict()})
+
+
+@typed_endpoint_without_parameters
+def get_catch_up_overview(
+    request: HttpRequest,
+    user_profile: UserProfile,
+) -> HttpResponse:
+    """
+    Generate a Claude-powered structured overview of ALL unread messages.
+    Fetches all unread messages then sends them to Claude for a global
+    summary with per-action-item and per-topic context links (US-08).
+    """
+    return _generate_catch_up_overview(request, user_profile, None)
+
+
+@typed_endpoint
+def post_catch_up_overview(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    summary_preferences: Json[str] = "",
+) -> HttpResponse:
+    """Same as GET, with optional JSON-encoded `summary_preferences` string in the POST body."""
+    return _generate_catch_up_overview(request, user_profile, summary_preferences)

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -249,3 +249,5 @@ RATE_LIMITING_RULES = {
         (86400, 1000),
     ],
 }
+
+DEBUG = True

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -93,7 +93,7 @@ from zerver.views.message_report import report_message_backend
 from zerver.views.message_send import render_message_backend, send_message_backend, zcommand_backend
 from zerver.views.message_summary import get_messages_summary
 from zerver.views.catch_up import get_catch_up, get_catch_up_summary, report_catch_up_usage
-from zerver.views.catchup_overview import get_catch_up_overview
+from zerver.views.catchup_overview import get_catch_up_overview, post_catch_up_overview
 from zerver.views.muted_users import mute_user, unmute_user
 from zerver.views.navigation_views import (
     add_navigation_view,
@@ -461,6 +461,10 @@ v1_api_and_json_patterns = [
         "catch-up/overview",
         GET=(
             get_catch_up_overview,
+            {"intentionally_undocumented"},
+        ),
+        POST=(
+            post_catch_up_overview,
             {"intentionally_undocumented"},
         ),
     ),


### PR DESCRIPTION
This work tightens the Catch up AI Summary flow end to end: the backend can take optional user summary preferences, the Claude prompt is more reader-specific and mention-aware, the web app loads the overview via POST with those preferences, and the tab gains collapsible instructions, a time saved visualization, and styling updates. It also fixes a bug where vim keys (e.g. l) were swallowed while typing in the preferences textarea.

# Backend
- POST /json/catch-up/overview (alongside existing GET): accepts optional summary_preferences (JSON-encoded string), length-capped, and passes it into summarization.
- zerver/views/catchup_overview.py: Refactors generation into _generate_catch_up_overview; loads UserMessage flags per message so the model can see how the reader was notified; uses TOPIC_SUMMARIZATION_PARAMETERS from settings for LiteLLM; maps LLM failures to a short, client-safe JsonableError while logging full trace server-side; adds concise logging around API key presence (length only).
- zerver/lib/catchup_claude.py: Prompt and schema updates for shorter output; second person / named reader; mention_to_reader on each message in context from flags; user_preferences and reader_full_name wired into the user message; optional LiteLLM debug verbosity when DEBUG is true (with an in-code warning about leaks).

# Frontend
- catch_up_data.ts: CatchUpOverviewResponse type and fetch_catch_up_overview posting to /json/catch-up/overview with clipped preferences.
- catch_up_ui.ts: Draft summary_preferences_draft across re-renders; collapsible AI summary instructions; regenerate control; AI Summary filter loads overview (with cache keyed by preferences); removes the old “list every message in the tab” approach in favor of the structured overview path; catch_up_time_saved context for a dummy time saved widget; resets expanded/prefs state on hide.
- Templates / CSS: catch_up_view.hbs updates, new catch_up_time_saved.hbs, substantial catch_up.css changes.
- Tests: catch_up_templates.test.cjs updated for the new template behavior.

# Bug fix
- hotkey.ts: Catch up vim/arrow navigation runs only when !processing_text(), so typing l, h, etc. in the instructions -- textarea (or other inputs inside the view) is no longer intercepted.

# Config
- zproject/dev_settings.py: Adds DEBUG = True at the end of the file (verify this does not conflict with your normal dev defaults or duplicate DEBUG if it is set earlier).

# Testing
- Template tests: web/tests/catch_up_templates.test.cjs.
- Manually verify: AI Summary tab, POST overview with preferences, regenerate, stream filters, and typing full sentences (including l) in the preferences field with vim-style hotkeys enabled.
